### PR TITLE
Allow fullscreen for YouTube embeds

### DIFF
--- a/FilmsAndAnimations/index.html
+++ b/FilmsAndAnimations/index.html
@@ -19,17 +19,17 @@
             <div class="LeftSide">
                 <h2> My Favourites </h2>
                 <div class="FnAPage">
-                    <iframe src="https://www.youtube.com/embed/qe1rOE1KOtc?si=542zue5HrkXLw3K1" class="FnAYoutubeFrame"
+                    <iframe src="https://www.youtube.com/embed/qe1rOE1KOtc?si=542zue5HrkXLw3K1" class="FnAYoutubeFrame" allow="fullscreen"
                     frameborder="0" referrerpolicy="strict-origin-when-cross-origin" style="align-items: center;"></iframe>
                     
                     <br>
 
-                    <iframe src="https://www.youtube.com/embed/FqJK43aeMjA?si=vGmqDUQ-swNRJM2J" class="FnAYoutubeFrame"
+                    <iframe src="https://www.youtube.com/embed/FqJK43aeMjA?si=vGmqDUQ-swNRJM2J" class="FnAYoutubeFrame" allow="fullscreen"
                     frameborder="0" referrerpolicy="strict-origin-when-cross-origin" style="align-items: center;"></iframe>
                     
                     <br>
 
-                    <iframe src="https://www.youtube.com/embed/HJSIzDsilBI?si=4dqOrZrPk95z3vT3" class="FnAYoutubeFrame"
+                    <iframe src="https://www.youtube.com/embed/HJSIzDsilBI?si=4dqOrZrPk95z3vT3" class="FnAYoutubeFrame" allow="fullscreen"
                     frameborder="0" referrerpolicy="strict-origin-when-cross-origin" style="align-items: center;"></iframe>
 
                 </div>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/37518071-7baa-48a7-9fa1-4544b519a778)

After:
![image](https://github.com/user-attachments/assets/43037a38-706d-49a6-8ee4-452d5ae6ccb8)

Make sure to add `allow="fullscreen"` to the `<iframe>` elements in future.
Example:
```html
<iframe src="https://www.youtube.com/embed/qe1rOE1KOtc?si=542zue5HrkXLw3K1" class="FnAYoutubeFrame" allow="fullscreen" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" style="align-items: center;"></iframe>
```
